### PR TITLE
Updated Newtonsoft.Json and Nustache packages

### DIFF
--- a/Bounce.Config.Tests/Bounce.Config.Tests.csproj
+++ b/Bounce.Config.Tests/Bounce.Config.Tests.csproj
@@ -31,9 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bounce.Framework, Version=0.7.4832.18981, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Bounce.0.9.0\lib\net40\Bounce.Framework.dll</HintPath>
+    <Reference Include="Bounce.Framework, Version=0.7.5308.27601, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Bounce.0.9.3\lib\net40\Bounce.Framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="FS, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Bounce.Config.Tests/packages.config
+++ b/Bounce.Config.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bounce" version="0.9.0" targetFramework="net40" />
+  <package id="Bounce" version="0.9.3" targetFramework="net40" />
   <package id="FS" version="0.0.3" targetFramework="net40" />
   <package id="NUnit" version="2.6.2" targetFramework="net40" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net40" />

--- a/Bounce.Config.nuspec
+++ b/Bounce.Config.nuspec
@@ -10,8 +10,9 @@
     <description>template your web.configs with mustache</description>
     <tags>build CI deploy configuration</tags>
     <dependencies>
-      <dependency id="Newtonsoft.Json" version="5.0.3" />
-      <dependency id="Nustache" version="1.12.4.29" />
+      <dependency id="Bounce" version="0.9.3" />
+      <dependency id="Newtonsoft.Json" version="6.0.8" />
+      <dependency id="Nustache" version="1.15.1.3" />
     </dependencies>
   </metadata>
   <files>

--- a/Bounce.Config/Bounce.Config.csproj
+++ b/Bounce.Config/Bounce.Config.csproj
@@ -31,21 +31,21 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Bounce.Framework, Version=0.7.4832.18981, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Bounce.0.9.0\lib\net40\Bounce.Framework.dll</HintPath>
+    <Reference Include="Bounce.Framework, Version=0.7.5308.27601, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Bounce.0.9.3\lib\net40\Bounce.Framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.5.0.3\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Nustache.Core, Version=1.12.4.29, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Nustache.1.12.4.29\lib\net20\Nustache.Core.dll</HintPath>
+    <Reference Include="Nustache.Core, Version=1.15.1.3, Culture=neutral, PublicKeyToken=efd6f3d8f76ecd9f, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nustache.1.15.1.3\lib\net20\Nustache.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Bounce.Config/packages.config
+++ b/Bounce.Config/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bounce" version="0.9.0" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="5.0.3" targetFramework="net40" />
-  <package id="Nustache" version="1.12.4.29" targetFramework="net40" />
+  <package id="Bounce" version="0.9.3" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net40" />
+  <package id="Nustache" version="1.15.1.3" targetFramework="net40" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
I would be great if bounce could be updated to use more recent versions of Newtonsoft.Json and Nustache packages.
